### PR TITLE
ci: fix workflow conditionals for Docker publish to avoid parse-time failure

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    environment: actions
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -33,14 +36,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_TOKEN }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Extract Docker metadata (GHCR only)
-        if: ${{ !secrets.DOCKERHUB_USERNAME || !secrets.DOCKERHUB_TOKEN }}
+        if: ${{ !env.DOCKERHUB_USERNAME || !env.DOCKERHUB_TOKEN }}
         id: meta_ghcr
         uses: docker/metadata-action@v5
         with:
@@ -52,7 +55,7 @@ jobs:
             type=sha,format=short,prefix=${{ matrix.flavor }}-
 
       - name: Extract Docker metadata (GHCR + Docker Hub)
-        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_TOKEN }}
         id: meta_both
         uses: docker/metadata-action@v5
         with:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    environment: actions
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -20,6 +24,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -32,14 +37,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_TOKEN }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Extract Docker metadata (GHCR only)
-        if: ${{ !secrets.DOCKERHUB_USERNAME || !secrets.DOCKERHUB_TOKEN }}
+        if: ${{ !env.DOCKERHUB_USERNAME || !env.DOCKERHUB_TOKEN }}
         id: meta_ghcr
         uses: docker/metadata-action@v5
         with:
@@ -49,20 +54,18 @@ jobs:
             type=raw,value=${{ matrix.flavor }}
             type=raw,value=latest,enable=${{ matrix.flavor == 'full' }}
             type=sha,format=short,prefix=${{ matrix.flavor }}-
-
       - name: Extract Docker metadata (GHCR + Docker Hub)
-        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_TOKEN }}
         id: meta_both
         uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+            docker.io/${{ github.repository }}
           tags: |
             type=raw,value=${{ matrix.flavor }}
             type=raw,value=latest,enable=${{ matrix.flavor == 'full' }}
             type=sha,format=short,prefix=${{ matrix.flavor }}-
-
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,10 +13,6 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    environment: actions
-    env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -37,14 +32,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_TOKEN }}
+        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract Docker metadata (GHCR only)
-        if: ${{ !env.DOCKERHUB_USERNAME || !env.DOCKERHUB_TOKEN }}
+        if: ${{ !secrets.DOCKERHUB_USERNAME || !secrets.DOCKERHUB_TOKEN }}
         id: meta_ghcr
         uses: docker/metadata-action@v5
         with:
@@ -56,13 +51,13 @@ jobs:
             type=sha,format=short,prefix=${{ matrix.flavor }}-
 
       - name: Extract Docker metadata (GHCR + Docker Hub)
-        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_TOKEN }}
+        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         id: meta_both
         uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            docker.io/${{ github.repository }}
+            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
           tags: |
             type=raw,value=${{ matrix.flavor }}
             type=raw,value=latest,enable=${{ matrix.flavor == 'full' }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -54,6 +54,7 @@ jobs:
             type=raw,value=${{ matrix.flavor }}
             type=raw,value=latest,enable=${{ matrix.flavor == 'full' }}
             type=sha,format=short,prefix=${{ matrix.flavor }}-
+
       - name: Extract Docker metadata (GHCR + Docker Hub)
         if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_TOKEN }}
         id: meta_both
@@ -66,6 +67,7 @@ jobs:
             type=raw,value=${{ matrix.flavor }}
             type=raw,value=latest,enable=${{ matrix.flavor == 'full' }}
             type=sha,format=short,prefix=${{ matrix.flavor }}-
+
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract Docker metadata (GHCR only)
-        if: ${{ secrets.DOCKERHUB_USERNAME == '' || secrets.DOCKERHUB_TOKEN == '' }}
+        if: ${{ !secrets.DOCKERHUB_USERNAME || !secrets.DOCKERHUB_TOKEN }}
         id: meta_ghcr
         uses: docker/metadata-action@v5
         with:
@@ -52,7 +52,7 @@ jobs:
             type=sha,format=short,prefix=${{ matrix.flavor }}-
 
       - name: Extract Docker metadata (GHCR + Docker Hub)
-        if: secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN
+        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         id: meta_both
         uses: docker/metadata-action@v5
         with:


### PR DESCRIPTION
Summary
- Normalize secrets conditionals in .github/workflows/publish-docker.yml to use boolean negation/truthiness.
  - GHCR-only metadata step: if: ${{ !secrets.DOCKERHUB_USERNAME || !secrets.DOCKERHUB_TOKEN }}
  - GHCR + Docker Hub metadata step: if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
- This avoids expression parsing/validation pitfalls that can cause a run to fail before jobs are scheduled.

Why
- The workflow run triggered by merging PR #3 failed with 0 jobs (parse/validation stage):
  - Run: https://github.com/jcoffi/cgm-mcp/actions/runs/17303608324
  - Status: completed, Conclusion: failure, Jobs: 0
  - Logs endpoint returned 404 (no job logs exist when the workflow fails at parse time).
  - Check suites API shows failure with no check runs (total_count = 0).

What changed
- Replace string-comparison based conditionals with boolean forms:
  - From: ${{ secrets.DOCKERHUB_USERNAME == '' || secrets.DOCKERHUB_TOKEN == '' }}
    To:   ${{ !secrets.DOCKERHUB_USERNAME || !secrets.DOCKERHUB_TOKEN }}
  - From: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
    To:   ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}

Notes
- Triggers for this workflow are push to main, tags v*, and workflow_dispatch; it will not auto-run for this PR branch until merged or manually dispatched.
- If desired, we can add a `pull_request` trigger or I can manually dispatch a test run on this branch.

Co-authored-by: openhands <openhands@all-hands.dev>