### PR TITLE
chore: align scripts and setup.sh with uv-based workflow (no local venv)

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -103,9 +103,21 @@ run_tests() {
 format_code() {
     print_status "Formatting code via uvx..."
     if command -v uvx >/dev/null 2>&1; then
-        uvx -q --from black black src/ tests/ examples/ --line-length 88 || print_warning "black issues"
-        uvx -q --from isort isort src/ tests/ examples/ --profile black || print_warning "isort issues"
-        print_success "Formatting completed"
+        uvx -q --from black black src/ tests/ examples/ --line-length 88
+        BLACK_STATUS=$?
+        uvx -q --from isort isort src/ tests/ examples/ --profile black
+        ISORT_STATUS=$?
+        if [ $BLACK_STATUS -eq 0 ] && [ $ISORT_STATUS -eq 0 ]; then
+            print_success "Formatting completed"
+        else
+            if [ $BLACK_STATUS -ne 0 ] && [ $ISORT_STATUS -ne 0 ]; then
+                print_warning "Both black and isort encountered issues"
+            elif [ $BLACK_STATUS -ne 0 ]; then
+                print_warning "black encountered issues"
+            elif [ $ISORT_STATUS -ne 0 ]; then
+                print_warning "isort encountered issues"
+            fi
+        fi
     else
         print_warning "uvx not found; skipping formatting"
     fi
@@ -115,10 +127,11 @@ format_code() {
 type_check() {
     print_status "Running type checks via uvx..."
     if command -v uvx >/dev/null 2>&1; then
-        uvx -q --from mypy mypy src/cgm_mcp --ignore-missing-imports || {
+        if uvx -q --from mypy mypy src/cgm_mcp --ignore-missing-imports; then
+            print_success "Type checking completed successfully"
+        else
             print_warning "Type checking found some issues, but continuing..."
-        }
-        print_success "Type checking completed"
+        fi
     else
         print_warning "uvx not found; skipping type checking"
     fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,44 +52,19 @@ check_python() {
     fi
 }
 
-# Create virtual environment
+# Environment setup (uvx-based)
 create_venv() {
-    print_status "Creating virtual environment..."
-    
-    if [ ! -d "venv" ]; then
-        python3 -m venv venv
-        print_success "Virtual environment created"
-    else
-        print_warning "Virtual environment already exists"
-    fi
+    print_status "No local virtual environment will be created; using uv-based execution"
 }
 
-# Activate virtual environment
+# Activate environment (uvx-based)
 activate_venv() {
-    print_status "Activating virtual environment..."
-    source venv/bin/activate
-    print_success "Virtual environment activated"
+    print_status "No environment activation required; tools run via uv/uvx"
 }
 
-# Install dependencies
+# Install dependencies (uv-based; no persistent install)
 install_dependencies() {
-    print_status "Installing dependencies..."
-    
-    # Upgrade pip
-    pip install --upgrade pip
-    
-    # Install requirements
-    if [ -f "requirements.txt" ]; then
-        pip install -r requirements.txt
-        print_success "Dependencies installed"
-    else
-        print_error "requirements.txt not found"
-        exit 1
-    fi
-    
-    # Install development dependencies
-    pip install pytest pytest-asyncio pytest-cov black isort mypy
-    print_success "Development dependencies installed"
+    print_status "Skipping persistent dependency installation; use uv/uvx to run commands with resolved deps as needed"
 }
 
 # Setup environment file
@@ -112,50 +87,40 @@ setup_env() {
 
 # Run tests
 run_tests() {
-    print_status "Running tests..."
-    
-    if command -v pytest &> /dev/null; then
-        pytest tests/ -v
+    print_status "Running tests via uvx..."
+    if command -v uvx >/dev/null 2>&1; then
+        uvx -q --from pytest pytest tests/ -v || {
+            print_error "Tests failed"
+            exit 1
+        }
         print_success "Tests completed"
     else
-        print_error "pytest not found"
-        exit 1
+        print_warning "uvx not found; skipping tests"
     fi
 }
 
 # Format code
 format_code() {
-    print_status "Formatting code..."
-    
-    # Format with black
-    if command -v black &> /dev/null; then
-        black src/ tests/ examples/ --line-length 88
-        print_success "Code formatted with black"
+    print_status "Formatting code via uvx..."
+    if command -v uvx >/dev/null 2>&1; then
+        uvx -q --from black black src/ tests/ examples/ --line-length 88 || print_warning "black issues"
+        uvx -q --from isort isort src/ tests/ examples/ --profile black || print_warning "isort issues"
+        print_success "Formatting completed"
     else
-        print_warning "black not found, skipping formatting"
-    fi
-    
-    # Sort imports with isort
-    if command -v isort &> /dev/null; then
-        isort src/ tests/ examples/ --profile black
-        print_success "Imports sorted with isort"
-    else
-        print_warning "isort not found, skipping import sorting"
+        print_warning "uvx not found; skipping formatting"
     fi
 }
 
 # Type checking
 type_check() {
-    print_status "Running type checks..."
-
-    if command -v mypy &> /dev/null; then
-        # Only check our code, exclude external libraries
-        mypy src/cgm_mcp --ignore-missing-imports --exclude venv/ || {
+    print_status "Running type checks via uvx..."
+    if command -v uvx >/dev/null 2>&1; then
+        uvx -q --from mypy mypy src/cgm_mcp --ignore-missing-imports || {
             print_warning "Type checking found some issues, but continuing..."
         }
         print_success "Type checking completed"
     else
-        print_warning "mypy not found, skipping type checking"
+        print_warning "uvx not found; skipping type checking"
     fi
 }
 
@@ -179,17 +144,17 @@ show_usage() {
     echo "1. Edit .env file with your API keys:"
     echo "   nano .env"
     echo ""
-    echo "2. Activate virtual environment:"
-    echo "   source venv/bin/activate"
+    echo "2. Start the server (modelless):"
+    echo "   uvx -q --from . cgm-mcp-modelless"
     echo ""
-    echo "3. Start the server:"
-    echo "   python main.py"
+    echo "3. Start the server (with LLM provider):"
+    echo "   uvx -q --from . cgm-mcp"
     echo ""
     echo "4. Run tests:"
-    echo "   pytest tests/"
+    echo "   uvx -q --from pytest pytest tests/"
     echo ""
     echo "5. Run examples:"
-    echo "   python examples/example_usage.py"
+    echo "   uv run python examples/example_usage.py"
     echo ""
     echo "For more information, see README.md"
 }

--- a/scripts/start_local.sh
+++ b/scripts/start_local.sh
@@ -78,14 +78,7 @@ done
 
 print_status "Starting CGM MCP Server with local models..."
 
-# Check if virtual environment exists
-if [ ! -d "venv" ]; then
-    print_error "Virtual environment not found. Please run setup.sh first."
-    exit 1
-fi
-
-# Activate virtual environment
-source venv/bin/activate
+# Using the current Python environment. No venv activation here.
 
 # Set configuration based on provider
 if [ -z "$CONFIG_FILE" ]; then
@@ -109,7 +102,7 @@ if [ -z "$CONFIG_FILE" ]; then
     esac
 fi
 
-# Check if config file exists
+# Require config file if specified or defaulted
 if [ ! -f "$CONFIG_FILE" ]; then
     print_error "Configuration file not found: $CONFIG_FILE"
     exit 1
@@ -154,7 +147,7 @@ print_status "Model: $MODEL"
 print_status "Config: $CONFIG_FILE"
 print_status "Port: $PORT"
 
-# Start the server
+# Start the server in the current environment
 print_status "Starting CGM MCP Server..."
 python main.py --config "$CONFIG_FILE" --log-level INFO
 

--- a/scripts/start_modelless.sh
+++ b/scripts/start_modelless.sh
@@ -91,14 +91,7 @@ done
 
 print_status "Starting CGM MCP Server (Model-agnostic)..."
 
-# Check if virtual environment exists
-if [ ! -d "venv" ]; then
-    print_error "Virtual environment not found. Please run setup.sh first."
-    exit 1
-fi
-
-# Activate virtual environment
-source venv/bin/activate
+# Using the current Python environment. No venv activation here.
 
 # Build command arguments
 CMD_ARGS=()
@@ -116,7 +109,6 @@ if [ -n "$LOG_LEVEL" ]; then
 fi
 
 if [ -n "$CACHE_DIR" ]; then
-    # Create cache directory if it doesn't exist
     mkdir -p "$CACHE_DIR"
     CMD_ARGS+=(--cache-dir "$CACHE_DIR")
 fi
@@ -151,8 +143,8 @@ print_status "  • cgm_get_file_content - Detailed file analysis"
 print_status "  • cgm_find_related_code - Code relationship discovery"
 print_status "  • cgm_extract_context - Context extraction for external models"
 
-# Start the server
+# Start the server in the current environment
 print_status "Starting server..."
 python main_modelless.py "${CMD_ARGS[@]}"
 
-print_success "CGM MCP Server (Model-agnostic) started successfully!"
+print_success "CGM MCP Server (Model-agnostic) started successfully!" 

--- a/scripts/start_modelless.sh
+++ b/scripts/start_modelless.sh
@@ -147,4 +147,4 @@ print_status "  • cgm_extract_context - Context extraction for external models
 print_status "Starting server..."
 python main_modelless.py "${CMD_ARGS[@]}"
 
-print_success "CGM MCP Server (Model-agnostic) started successfully!" 
+print_success "CGM MCP Server (Model-agnostic) started successfully!"


### PR DESCRIPTION
Summary
- Remove explicit virtualenv usage from setup and startup scripts; standardize on uv/uvx for running tools and entry points.

Key Changes
- scripts/setup.sh
  - Remove venv creation/activation and persistent pip installs
  - Run dev tools via uvx (pytest, black, isort, mypy)
  - Update usage to recommend uvx console scripts and uv run where appropriate
- scripts/start_local.sh
  - Do not activate venv; rely on current environment
  - Preserve provider/config handling; start via `python main.py --config ...`
- scripts/start_modelless.sh
  - Do not activate venv; rely on current environment
  - Preserve CLI args; start via `python main_modelless.py ...`

Rationale
- Repository has migrated to uvx-based execution. Removing in-script venv usage avoids double environment management and aligns with pyproject console_scripts (cgm-mcp, cgm-mcp-modelless) and README direction.

Follow-ups (Optional)
- Update README/docs to prefer uvx console scripts throughout, or present both uvx and python paths for local dev.
- Consider supporting `CGM_CONFIG_PATH` env var in console scripts to bridge `--config` use when invoking via uvx.

Testing
- Ran local script audits to ensure no lingering venv activation in scripts.
- Verified setup.sh invokes dev tools via uvx when available.

Co-authored-by: openhands <openhands@all-hands.dev>