### PR TITLE
Align MCP dependency and ensure tool namespace compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=0.9.0",
+    "mcp>=1.0.0",
     "pydantic>=2.0.0",
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",


### PR DESCRIPTION
This PR aligns the MCP dependency across packaging files and ensures compatibility with OpenHands' MCP tool registration pipeline.

Changes:
- Align mcp dependency in pyproject.toml to mcp>=1.0.0 (requirements.txt already had this)

Why:
- OpenHands expects MCP tool registration to conform to the latest MCP client/server packages. Mismatched versions can cause tools declared via config or EXTRA_INFO to not be registered in the runtime namespace, leading to "declared but not in tool namespace"-style issues.

Testing:
- Local repo build metadata updated; server code already imports mcp.server.* APIs compatible with 1.0.x

Follow-ups (if needed):
- If you see any runtime warnings about tools not being registered, verify MCP server startup logs and client config. We can extend CI to smoke-test `list_tools` from the server to catch regressions.
