### PR TITLE
Fix MCP server initialization bug

### DIFF
--- a/src/cgm_mcp/server.py
+++ b/src/cgm_mcp/server.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 from mcp.server import Server
+from mcp.server.lowlevel.server import NotificationOptions
 from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import (
@@ -355,7 +356,7 @@ class CGMServer:
                     server_name="cgm-mcp",
                     server_version="0.1.0",
                     capabilities=self.server.get_capabilities(
-                        notification_options=None,
+                        notification_options=NotificationOptions(),
                         experimental_capabilities=None,
                     ),
                 ),


### PR DESCRIPTION
## Description
This PR fixes a critical bug in the CGM MCP server initialization that was preventing the server from starting with LLM integration.

## Problem
The server was failing to start with the error:
```
AttributeError: 'NoneType' object has no attribute 'resources_changed'
```

This occurred because the `get_capabilities()` method in the MCP server was being called with `notification_options=None`, but the MCP library expects a proper `NotificationOptions` object.

## Solution
- Import `NotificationOptions` from `mcp.server.lowlevel.server`
- Change the `notification_options` parameter from `None` to `NotificationOptions()` in the `get_capabilities()` call

## Changes Made
- **src/cgm_mcp/server.py**: Added import and fixed the parameter

## Testing
- Server now starts successfully with both OpenAI and Anthropic LLM providers
- All components (Rewriter, Retriever, Reranker, Reader, GraphBuilder) load correctly
- MCP protocol communication is functional

## Impact
This fix enables the CGM MCP server to run with LLM integration, allowing it to provide advanced code analysis capabilities through MCP clients like Claude Desktop.