### PR TITLE
Fix TaskGroup sub-exception by providing NotificationOptions to avoid AttributeError on None

### DIFF
--- a/src/cgm_mcp/server.py
+++ b/src/cgm_mcp/server.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 from loguru import logger
 from mcp.server import Server
 from mcp.server.models import InitializationOptions
+from mcp.server.lowlevel.server import NotificationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import (
     EmbeddedResource,
@@ -355,7 +356,7 @@ class CGMServer:
                     server_name="cgm-mcp",
                     server_version="0.1.0",
                     capabilities=self.server.get_capabilities(
-                        notification_options=None,
+                        notification_options=NotificationOptions(resources_changed=True),
                         experimental_capabilities=None,
                     ),
                 ),


### PR DESCRIPTION
The server was crashing due to notification_options=None in get_capabilities(), causing AttributeError in MCP library. Updated import to use NotificationOptions from mcp.server.lowlevel.server and set notification_options=NotificationOptions(resources_changed=True) to enable resource notifications and resolve the None access.

This fix enables the server to start without the TaskGroup sub-exception error, allowing MCP tools to be available via stdio.

Co-authored-by: openhands <openhands@all-hands.dev>