### PR TITLE
fix(cli): wrap async main in sync entrypoint for uvx (MCP STDIO)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ Repository = "https://github.com/yangweijie/cgm-mcp"
 Documentation = "https://github.com/yangweijie/cgm-mcp/blob/main/README.md"
 
 [project.scripts]
-cgm-mcp = "cgm_mcp.server:main"
+cgm-mcp = "cgm_mcp.server:cli_main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/cgm_mcp/server.py
+++ b/src/cgm_mcp/server.py
@@ -370,5 +370,10 @@ async def main():
     await server.run()
 
 
+def cli_main():
+    """Synchronous console entry point wrapper."""
+    asyncio.run(main())
+
+
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Summary
- Fixes MCP STDIO startup when launched via `uvx --from ... cgm-mcp` by ensuring the console script is synchronous.

What changed
- Added `cli_main()` in `src/cgm_mcp/server.py` to call `asyncio.run(main())`.
- Updated `pyproject.toml` console script mapping to `cgm_mcp.server:cli_main`.

Why
- Previously, the console script pointed to `cgm_mcp.server:main`, which is an `async def`. When executed by `uvx`, this produced `RuntimeWarning: coroutine 'main' was never awaited` and prevented the STDIO server from loading in OpenHands.

How to test
- In a clean environment, run:
  - `uvx -q --from git+https://github.com/jcoffi/cgm-mcp.git cgm-mcp --help` (after merge)
  - Should no longer print the coroutine warning and should start the STDIO server normally.

Notes
- The `__main__` guard already uses `asyncio.run(main())`, so `python -m cgm_mcp.server` always worked. This PR makes the console script entry point consistent with that behavior.

Co-authored-by: openhands <openhands@all-hands.dev>