### PR TITLE
Fix indentation of list_tools decorator in server.py

### DIFF
--- a/src/cgm_mcp/server.py
+++ b/src/cgm_mcp/server.py
@@ -156,7 +156,7 @@ class CGMServer:
                 return json.dumps(payload, indent=2)
             else:
                 raise ValueError(f"Unknown resource: {uri}")
-@self.server.list_tools()
+        @self.server.list_tools()
         async def handle_list_tools() -> List[Tool]:
             """List available tools"""
             return [


### PR DESCRIPTION
This PR fixes an indentation error in src/cgm_mcp/server.py that caused an ImportError when running the package. The mis-indented decorator prevented the module from importing cleanly and blocked uvx --from ... installations.\n\nCo-authored-by: openhands <openhands@all-hands.dev>